### PR TITLE
Remove unused export of fs.

### DIFF
--- a/.profile
+++ b/.profile
@@ -73,9 +73,6 @@ fs() {
 	printf "done\n"
 }
 
-# Makes 'fs' available in git hooks
-export -f fs
-
 # Open a new pull request. (requires GitHub Hub, see hub.github.com)
 #
 # usage:


### PR DESCRIPTION
Causes conflicts with Pandora's setup scripts and does not appear to actually be used.